### PR TITLE
fix chance task error by updating task name

### DIFF
--- a/cypress/tests/integration/real-world-app/transaction.spec.js
+++ b/cypress/tests/integration/real-world-app/transaction.spec.js
@@ -14,7 +14,7 @@ describe('Transactions', () => {
     // the Real World App still redirects the user to the login page if using loginByJSON
     // cy.loginByJSON()
 
-    cy.task('chanceSeed').then((seed) => {
+    cy.task('chance:seed').then((seed) => {
       chance = new Chance(seed)
     })
 


### PR DESCRIPTION
This PR fixes the integration test failing by updating the name of the Cypress chance task.